### PR TITLE
check when trying to divide by T=0 and initialize PCurFrame

### DIFF
--- a/C2_vs2017/Characters.cpp
+++ b/C2_vs2017/Characters.cpp
@@ -8617,8 +8617,10 @@ void CreateChMorphedModel(TCharacter *cptr)
 		PSplineD = PCurFrame & 0xFF;
 		PCurFrame = (PCurFrame >> 8);
 	}
-
-
+	else
+	{
+		PCurFrame = 0;
+	}
 
 	if (!MORPHA)
 	{

--- a/C2_vs2017/RendererD3D.cpp
+++ b/C2_vs2017/RendererD3D.cpp
@@ -1023,9 +1023,11 @@ void d3dDetectCaps()
   PrintLog(logt);
   ResetTextureMap();
 
-  wsprintf(logt, "DETECTED: Texture transfer speed: %dK/sec.\n", 128*10000 / T);
-  PrintLog(logt);
-
+  if (T != 0)
+  {
+    wsprintf(logt, "DETECTED: Texture transfer speed: %dK/sec.\n", 128 * 10000 / T);
+    PrintLog(logt);
+  }
 
   DDSURFACEDESC ddsd;
   ZeroMemory( &ddsd, sizeof(DDSURFACEDESC) );


### PR DESCRIPTION
Check when trying to divide by T=0 and initialize PCurFrame, which is always used further